### PR TITLE
chore: until-build to be 232.*

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
   <id>some.awesome</id>
   <name>Nyan Progress Bar</name>
   <version>1.14</version>
-  <idea-version since-build="192"/>
+  <idea-version since-build="192" until-build="232.*"/>
   <vendor email="dmitry.batkovich@jetbrains.com">Dmitry Batkovich</vendor>
 
   <description><![CDATA[


### PR DESCRIPTION
- Avoid the problem for users who upgrade IDE to 2023.3.*
- Work around for #9 