### PR TITLE
fix: support IntelliJ 2023.3 and later

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
   <id>some.awesome</id>
   <name>Nyan Progress Bar</name>
   <version>1.14</version>
-  <idea-version since-build="192"/>
+  <idea-version since-build="193"/>
   <vendor email="dmitry.batkovich@jetbrains.com">Dmitry Batkovich</vendor>
 
   <description><![CDATA[
@@ -36,9 +36,8 @@
     <!-- Add your actions here -->
   </actions>
 
-  <application-components>
-    <component>
-      <implementation-class>NyanApplicationComponent</implementation-class>
-    </component>
-  </application-components>
+  <applicationListeners>
+    <listener class="NyanApplicationComponent" topic="com.intellij.ide.ui.LafManagerListener"/>
+    <listener class="NyanApplicationComponent" topic="com.intellij.openapi.application.ApplicationActivationListener"/>
+  </applicationListeners>
 </idea-plugin>

--- a/src/NyanApplicationComponent.java
+++ b/src/NyanApplicationComponent.java
@@ -2,12 +2,20 @@ import com.intellij.ide.ui.LafManager;
 
 import javax.swing.*;
 
-public class NyanApplicationComponent {
+public class NyanApplicationComponent implements LafManagerListener, ApplicationActivationListener {
     public NyanApplicationComponent() {
-        LafManager.getInstance().addLafManagerListener(__ -> updateProgressBarUi());
+    }
+
+    @Override
+    public void lookAndFeelChanged(@NotNull LafManager lafManager) {
+        // see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html
         updateProgressBarUi();
     }
 
+    @Override
+    public void applicationActivated(@NotNull IdeFrame ideFrame) {
+        updateProgressBarUi();
+    }
     private void updateProgressBarUi() {
         UIManager.put("ProgressBarUI", NyanProgressBarUi.class.getName());
         UIManager.getDefaults().put(NyanProgressBarUi.class.getName(), NyanProgressBarUi.class);

--- a/src/NyanProgressBarUi.java
+++ b/src/NyanProgressBarUi.java
@@ -5,10 +5,10 @@ import com.intellij.ui.JBColor;
 import com.intellij.util.ui.GraphicsUtil;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
-import sun.swing.SwingUtilities2;
 
 import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.basic.BasicGraphicsUtils;
 import javax.swing.plaf.basic.BasicProgressBarUI;
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
@@ -239,11 +239,11 @@ public class NyanProgressBarUi extends BasicProgressBarUI {
 
         if (progressBar.getOrientation() == SwingConstants.HORIZONTAL) {
             g2.setColor(getSelectionBackground());
-            SwingUtilities2.drawString(progressBar, g2, progressString,
+            BasicGraphicsUtils.drawString(progressBar, g2, progressString,
                     renderLocation.x, renderLocation.y);
             g2.setColor(getSelectionForeground());
             g2.clipRect(fillStart, y, amountFull, h);
-            SwingUtilities2.drawString(progressBar, g2, progressString,
+            BasicGraphicsUtils.drawString(progressBar, g2, progressString,
                     renderLocation.x, renderLocation.y);
         } else { // VERTICAL
             g2.setColor(getSelectionBackground());
@@ -252,11 +252,11 @@ public class NyanProgressBarUi extends BasicProgressBarUI {
             g2.setFont(progressBar.getFont().deriveFont(rotate));
             renderLocation = getStringPlacement(g2, progressString,
                     x, y, w, h);
-            SwingUtilities2.drawString(progressBar, g2, progressString,
+            BasicGraphicsUtils.drawString(progressBar, g2, progressString,
                     renderLocation.x, renderLocation.y);
             g2.setColor(getSelectionForeground());
             g2.clipRect(x, fillStart, w, amountFull);
-            SwingUtilities2.drawString(progressBar, g2, progressString,
+            BasicGraphicsUtils.drawString(progressBar, g2, progressString,
                     renderLocation.x, renderLocation.y);
         }
         g2.setClip(oldClip);


### PR DESCRIPTION
- Use API requires version 193
- Use BasicGraphicsUtils instead of internal sun.swing.SwingUtilities2
- Use `ApplicationActivationListener` instead of registering as `application-component`
- Use `LafManagerListener` instead of deprecated `LafManager#addLafManagerListener`
- solves #9 